### PR TITLE
Correção nos links da Casa do código e Contratado.me

### DIFF
--- a/_posts/2016-01-29-devnaestrada-henrique-bastos.md
+++ b/_posts/2016-01-29-devnaestrada-henrique-bastos.md
@@ -23,9 +23,9 @@ Ganhador: **Luiz Augusto da Silva Crisostomo**
   Também quero apoiar!
 </a>
 
-[CasaDoCódigo](http://devs.contratado.me/)
+[CasaDoCódigo](http://www.casadocodigo.com.br/)
 
-[Contratado.me](http://www.casadocodigo.com.br/)
+[Contratado.me](http://devs.contratado.me/)
 
 [Twitter Henrique Bastos](https://twitter.com/henriquebastos)
 


### PR DESCRIPTION
Correção nos links da Casa do código e Contratado.me, que estavam invertidos.