### PR TITLE
fix margin pagination button in iphone retina resolution

### DIFF
--- a/public/assets/scss/modules/navigation/_pagination.scss
+++ b/public/assets/scss/modules/navigation/_pagination.scss
@@ -8,5 +8,9 @@
     &:first-child {
       margin-left: 0;
     }
+
+	@media screen and (max-width: $iphone-retina) {
+		margin-left: 15px;
+	}
   }
 }


### PR DESCRIPTION
- Na resolução 320, o **margin-left: 30px** aplicado na classe **.pagination .btn** está fazendo o botão **Avançar** ficar com o alinhamento inadequado quando o botão **Voltar** aparece na página;
- Reduzi o **margin-left** pela metade no break point $iphone-retina.  