### PR TITLE
Fixed typo: Outrubro -> Outubro in index and post layouts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,7 +17,7 @@ layout: default
         {% when '7' %}Julho
         {% when '8' %}Agosto
         {% when '9' %}Setembro
-        {% when '10' %}Outrubro
+        {% when '10' %}Outubro
         {% when '11' %}Novembro
         {% when '12' %}Dezembro
       {% endcase %}

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ layout: default
           {% when '7' %}Julho
           {% when '8' %}Agosto
           {% when '9' %}Setembro
-          {% when '10' %}Outrubro
+          {% when '10' %}Outubro
           {% when '11' %}Novembro
           {% when '12' %}Dezembro
         {% endcase %}
@@ -33,8 +33,6 @@ layout: default
         {% if post.libsyn-image %}
           <img class="episode-artwork" src="https://assets.libsyn.com/secure/show/104268/{{ post.libsyn-image }}" alt="{{ post.home-title }}" />
         {% endif %}
-
-
 
         <a href="{{ post.url }}" class="episode-link">
           <h1 class="episode-title">{{ post.title }}</h1>


### PR DESCRIPTION
![your incredible giphy](http://gph.is/1MKR612)

### What?
Fixed October month name in `index` and `posts` layouts for generating new pages correctly.

_____
![screenshot please](https://drive.google.com/open?id=0B6LeLYMuphGmX3FWY2xlSmJDc1U)

