### PR TITLE
Posicionamento da label com a classe .nav-label na vizualização de mobile

### DIFF
--- a/_scss/modules/structure/_header.scss
+++ b/_scss/modules/structure/_header.scss
@@ -30,7 +30,7 @@ header {
   font-size: 28px;
   position: absolute;
   right: 15px;
-  top: 15px;
+  top: 39px;
 
   @media screen and (min-width: $tablet) {
     display: none;


### PR DESCRIPTION
O elemento:
`<label for="nav-btn" class="fa fa-bars nav-label" aria-hidden="true"></label>`
Não estava centralizado no header em vizualização de mobile com o posicionamento `top:15px`. Ele estava posicionado acima do `<a href="/" class="header-brand">`.

Calculando os espaçamentos dentro do header com o tamanho do elemento `<label>` modifiquei para `top: 39px;` para que ficasse centralizado de forma correta.

a alteração foi realizada na class `nav-label`.