### PR TITLE
Fixed header meta theme-color

### DIFF
--- a/_includes/structure/head.html
+++ b/_includes/structure/head.html
@@ -60,9 +60,9 @@
   <link rel="icon" type="image/png" sizes="96x96" href="{{ "assets/img/favicon/favicon-96x96.png" | prepend: site.baseurl }}">
   <link rel="icon" type="image/png" sizes="16x16" href="{{ "assets/img/favicon/favicon-16x16.png" | prepend: site.baseurl }}">
   <link rel="manifest" href="/manifest.json">
-  <meta name="msapplication-TileColor" content="#e67e22">
+  <meta name="msapplication-TileColor" content="#3CD52E">
   <meta name="msapplication-TileImage" content="{{ "assets/img/favicon/ms-icon-144x144.png" | prepend: site.baseurl }}">
-  <meta name="theme-color" content="#e67e22">
+  <meta name="theme-color" content="#3CD52E">
 
   <!-- Google Analytics -->
   {% if site.google_analytics %}


### PR DESCRIPTION
### What?
The new layout was using the **theme-color** from the old layout.
_____
![dne](https://user-images.githubusercontent.com/7614112/38916689-bf60d3ee-42be-11e8-96ea-5a6306b6bacc.png)


